### PR TITLE
Enhancement/mathiafl/manual seeds

### DIFF
--- a/web/src/blobs/blobs.module.css
+++ b/web/src/blobs/blobs.module.css
@@ -109,6 +109,10 @@
   display: flex;
 }
 
+.rightPos button:nth-child(n + 2) {
+  margin-left: 2px;
+}
+
 .fileContainer {
   position: relative;
 }
@@ -167,4 +171,29 @@
 
 .imageUploadGroup {
   margin-top: 3rem;
+}
+
+.textField {
+  width: 100%;
+  font-weight: normal;
+  color: var(--color-standard__white--text);
+  background-color: var(--color-standard__white);
+  /* transition: all 200ms ease-in; */
+
+  border: 1px solid var(--color-secondary4__shade2);
+  border-radius: 0.2rem;
+  padding: 0.1rem 0.4rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  padding-right: 20px;
+}
+
+.textField:focus,
+.textField:hover {
+  border-color: var(--color-secondary4__shade1);
+}
+
+.buttonGroup {
+  display: flex;
 }

--- a/web/src/blobs/blobs.module.css
+++ b/web/src/blobs/blobs.module.css
@@ -107,6 +107,7 @@
 
 .rightPos {
   display: flex;
+  margin: 1px 0;
 }
 
 .rightPos button:nth-child(n + 2) {
@@ -192,8 +193,4 @@
 .textField:focus,
 .textField:hover {
   border-color: var(--color-secondary4__shade1);
-}
-
-.buttonGroup {
-  display: flex;
 }

--- a/web/src/blobs/index.tsx
+++ b/web/src/blobs/index.tsx
@@ -121,7 +121,7 @@ const BlobGenerator: React.FC<{}> = () => {
 
           <NumberField onInput={setSeed} val={seed} label="Seed" />
 
-          <div className={css.rightPos} style={{ margin: "1px" }}>
+          <div className={css.rightPos}>
             <button className={css.smallButton} onClick={reshape} type="button">
               Random Seed
             </button>

--- a/web/src/blobs/index.tsx
+++ b/web/src/blobs/index.tsx
@@ -1,6 +1,11 @@
-import * as React from "react";
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import * as blobs2 from "blobs/v2";
-import { useState, useEffect, ChangeEvent, useRef } from "react";
 import {
   allColorRecords,
   randomColorRecord,
@@ -49,9 +54,8 @@ const BlobGenerator: React.FC<{}> = () => {
     y: number;
   }>({ x: 0, y: 0 });
 
-  const [seed, setSeed] = useState(Math.random());
-  const reshape = () => setSeed(Math.random());
-  useEffect(reshape, [points, randomness]);
+  const [seed, setSeed] = useState(Math.floor(Math.random() * 10 ** 16));
+  const reshape = () => setSeed(Math.floor(Math.random() * 10 ** 16));
 
   const random = () => {
     setPoints(pickRandom(DEFAULTS_POINTS));
@@ -59,6 +63,8 @@ const BlobGenerator: React.FC<{}> = () => {
     setColor(randomColorRecord());
     reshape();
   };
+  // Random seed initially, keep to tweak with points.
+  useEffect(random, []);
 
   const svgPath = blobs2.svgPath({
     seed,
@@ -112,6 +118,23 @@ const BlobGenerator: React.FC<{}> = () => {
               val={size}
             />
           </Group>
+
+          <Group name="Seed">
+            <NumberField onInput={setSeed} val={seed} />
+          </Group>
+
+          <div className={css.rightPos} style={{ margin: "1px" }}>
+            <button className={css.smallButton} onClick={reshape} type="button">
+              Random Seed
+            </button>
+            <CopyableText
+              Component="button"
+              className={css.smallButton}
+              overrideCopyValue={seed}
+            >
+              Copy seed
+            </CopyableText>
+          </div>
 
           {!image && (
             <Group name="Fill color">
@@ -241,6 +264,38 @@ const UploadFile: React.FC<{
         </button>
       )}
     </div>
+  );
+};
+
+const NumberField: React.FC<{
+  onInput: (value: number) => void;
+  val: number;
+  placeholder?: string;
+}> = ({ val, onInput, placeholder = "Enter value here" }) => {
+  const internalChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = Number(e.target.value);
+      if (
+        value < Number.MAX_SAFE_INTEGER &&
+        value >= 0 &&
+        !isNaN(value) &&
+        isFinite(value)
+      ) {
+        onInput(value);
+      }
+    },
+    [onInput]
+  );
+
+  return (
+    <input
+      key="numberField"
+      type="text"
+      onChange={internalChange}
+      value={val}
+      placeholder={placeholder}
+      className={css.textField}
+    />
   );
 };
 

--- a/web/src/blobs/index.tsx
+++ b/web/src/blobs/index.tsx
@@ -290,6 +290,7 @@ const NumberField: React.FC<{
     <>
       <label htmlFor="numberField">{label}</label>
       <input
+        aria-label={label}
         id="numberField"
         type="text"
         onChange={internalChange}

--- a/web/src/blobs/index.tsx
+++ b/web/src/blobs/index.tsx
@@ -64,7 +64,7 @@ const BlobGenerator: React.FC<{}> = () => {
     reshape();
   };
   // Random seed initially, keep to tweak with points.
-  useEffect(random, []);
+  useEffect(reshape, []);
 
   const svgPath = blobs2.svgPath({
     seed,

--- a/web/src/blobs/index.tsx
+++ b/web/src/blobs/index.tsx
@@ -119,9 +119,7 @@ const BlobGenerator: React.FC<{}> = () => {
             />
           </Group>
 
-          <Group name="Seed">
-            <NumberField onInput={setSeed} val={seed} />
-          </Group>
+          <NumberField onInput={setSeed} val={seed} label="Seed" />
 
           <div className={css.rightPos} style={{ margin: "1px" }}>
             <button className={css.smallButton} onClick={reshape} type="button">
@@ -270,8 +268,9 @@ const UploadFile: React.FC<{
 const NumberField: React.FC<{
   onInput: (value: number) => void;
   val: number;
+  label: string;
   placeholder?: string;
-}> = ({ val, onInput, placeholder = "Enter value here" }) => {
+}> = ({ val, onInput, placeholder = "Enter value here", label }) => {
   const internalChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const value = Number(e.target.value);
@@ -288,14 +287,17 @@ const NumberField: React.FC<{
   );
 
   return (
-    <input
-      key="numberField"
-      type="text"
-      onChange={internalChange}
-      value={val}
-      placeholder={placeholder}
-      className={css.textField}
-    />
+    <>
+      <label htmlFor="numberField">{label}</label>
+      <input
+        id="numberField"
+        type="text"
+        onChange={internalChange}
+        value={val}
+        placeholder={placeholder}
+        className={css.textField}
+      />
+    </>
   );
 };
 

--- a/web/src/components/copyable-text/index.tsx
+++ b/web/src/components/copyable-text/index.tsx
@@ -3,20 +3,26 @@ import * as React from "react";
 import css from "./style.module.css";
 import useConfirmationText from "../use-confirmation-text";
 
-export type CopyableTextProps = {
+export interface CopyableTextProps extends React.ComponentPropsWithoutRef<any> {
   children: string | number;
   Component?: React.ReactType;
   withConfirmation?: boolean;
-};
+  overrideCopyValue?: string | number;
+}
 
 const CopyableText: React.FC<CopyableTextProps> = ({
   children,
   Component = "div",
   withConfirmation = true,
+  className,
+  overrideCopyValue,
+  ...props
 }) => {
-  const handleCopy = () => {
+  const handleCopy = async () => {
     try {
-      navigator.clipboard.writeText(String(children));
+      navigator.clipboard.writeText(
+        String(overrideCopyValue ? overrideCopyValue : children)
+      );
     } catch (_) {}
   };
 
@@ -25,7 +31,11 @@ const CopyableText: React.FC<CopyableTextProps> = ({
   });
 
   return (
-    <Component onClick={onClick} className={css.copyable}>
+    <Component
+      onClick={onClick}
+      className={`${className || ""} ${css.copyable}`}
+      {...props}
+    >
       {children}
       {icon}
     </Component>


### PR DESCRIPTION
- Adds Input field for Seed
- Change value representation from float to int.
- Adds Overridable CopyValue as prop on CopyableText (rename?)
- Changes reshaping login, to only change seed on "Random Seed" button no on Points or Points Spread changes.
- Adds css to allow for multiple elements inside element with className "css.rightPos" 