### PR TITLE
Typography rework

### DIFF
--- a/packages/profile/src/typography/index.module.css
+++ b/packages/profile/src/typography/index.module.css
@@ -204,5 +204,5 @@ button,
 input,
 textarea {
   font-family: "Graphik Web", Arial, sans-serif;
-  font-size: 1rem;
+  font-size: inherit;
 }

--- a/packages/profile/src/typography/index.module.css
+++ b/packages/profile/src/typography/index.module.css
@@ -96,24 +96,28 @@
   font-display: swap;
 }
 
-html {
-  font-size: 20px;
-}
-@media (max-width: 1000px) {
-  html {
-    font-size: 16px;
-  }
-}
-@media (max-width: 800px) {
-  html {
-    font-size: 14px;
-  }
-}
+
+
 body {
   font-family: "Graphik Web", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: var(--color-standard__black);
+}
+
+html {
+  --font-size-min: 14;
+  --font-size-max: 20;
+  --viewport-min: 350;
+  --viewport-max: 1400;
+  font-size: calc( (var(--font-size-min) * 1px) + (var(--font-size-max) - var(--font-size-min)) * ((100vw - (var(--viewport-min) * 1px)) / (var(--viewport-max) - var(--viewport-min))) );
+  line-height: 1.6;
+}
+
+@media (min-width: 1400px) {
+  html {
+    font-size: calc( var(--font-size-max) * 1px );
+  }
 }
 
 h1,

--- a/packages/profile/src/typography/index.module.css
+++ b/packages/profile/src/typography/index.module.css
@@ -188,11 +188,11 @@ p {
 p + p {
   margin-top: 1rem;
 }
-p.lead {
+.lead {
   font-size: 1.5rem;
   line-height: 1.3;
 }
-p.caption {
+.caption {
   font-size: 0.65rem;
   line-height: 1.4;
 }

--- a/packages/profile/src/typography/index.module.css
+++ b/packages/profile/src/typography/index.module.css
@@ -110,15 +110,11 @@ html {
   --font-size-max: 22;
   --viewport-min: 400;
   --viewport-max: 1400;
-  font-size: calc( (var(--font-size-min) * 1px) + (var(--font-size-max) - var(--font-size-min)) * ((100vw - (var(--viewport-min) * 1px)) / (var(--viewport-max) - var(--viewport-min))) );
   line-height: 1.6;
+  /* Explanation for this madness: https://css-tricks.com/snippets/css/fluid-typography/ */
+  font-size: calc( (var(--font-size-min) * 1px) + (var(--font-size-max) - var(--font-size-min)) * ((100vw - (var(--viewport-min) * 1px)) / (var(--viewport-max) - var(--viewport-min))) );
+  
 }
-
-/* @media (min-width: 1400px) {
-  html {
-    font-size: calc( var(--font-size-max) * 1px );
-  }
-} */
 
 h1,
 h2,

--- a/packages/profile/src/typography/index.module.css
+++ b/packages/profile/src/typography/index.module.css
@@ -148,7 +148,7 @@ h3 {
   font-weight: normal;
 }
 
-h3.fancy {
+.fancy {
   font-family: "Recoleta", serif;
 }
 
@@ -165,9 +165,6 @@ h4 {
   font-size: 1.5rem;
   font-weight: 500;
   margin-bottom: 0.5rem;
-}
-h4.fancy {
-  font-family: "Recoleta", serif;
 }
 * + h4 {
   margin-top: 3rem;

--- a/packages/profile/src/typography/index.module.css
+++ b/packages/profile/src/typography/index.module.css
@@ -107,18 +107,18 @@ body {
 
 html {
   --font-size-min: 14;
-  --font-size-max: 20;
-  --viewport-min: 350;
+  --font-size-max: 22;
+  --viewport-min: 400;
   --viewport-max: 1400;
   font-size: calc( (var(--font-size-min) * 1px) + (var(--font-size-max) - var(--font-size-min)) * ((100vw - (var(--viewport-min) * 1px)) / (var(--viewport-max) - var(--viewport-min))) );
   line-height: 1.6;
 }
 
-@media (min-width: 1400px) {
+/* @media (min-width: 1400px) {
   html {
     font-size: calc( var(--font-size-max) * 1px );
   }
-}
+} */
 
 h1,
 h2,


### PR DESCRIPTION
This PR attempts to make typography scale according to viewport size.
Read more about it here: https://css-tricks.com/snippets/css/fluid-typography/

Also did some minor tweaking of selectors such as `p.lead` to be just `.lead`
instead of having a separate rule of `h3.fancy`, `h4.fancy`, only `.fancy` would be required now.