### PR TITLE
Fix: #34 - Blob generator forces images to be square

### DIFF
--- a/web/styleguide/components/svg-blob/index.tsx
+++ b/web/styleguide/components/svg-blob/index.tsx
@@ -117,16 +117,6 @@ const SvgBlob: React.FC<SvgBlobProps> = React.memo(
 );
 export default SvgBlob;
 
-const calculateScaleFromDimensions = (
-  dimensions: { height: number; width: number },
-  generalScale: number,
-) => {
-  const [h, w] = [dimensions.height, dimensions.width];
-  const scaleHeight = h > w ? (h / w) * generalScale : generalScale;
-  const scaleWidth = w > h ? (w / h) * generalScale : generalScale;
-  return { height: scaleHeight, width: scaleWidth };
-};
-
 export async function blobAsString(opts: SvgBlobProps) {
   if (opts.image) {
     return blobImageAsString(opts);
@@ -209,3 +199,13 @@ async function blobImageAsString({
     </svg>
 `;
 }
+
+const calculateScaleFromDimensions = (
+  dimensions: { height: number; width: number },
+  generalScale: number,
+) => {
+  const { height: h, width: w } = dimensions;
+  const scaleHeight = h > w ? (h / w) * generalScale : generalScale;
+  const scaleWidth = w > h ? (w / h) * generalScale : generalScale;
+  return { height: scaleHeight, width: scaleWidth };
+};

--- a/web/styleguide/components/svg-blob/index.tsx
+++ b/web/styleguide/components/svg-blob/index.tsx
@@ -32,6 +32,9 @@ const SvgBlob: React.FC<SvgBlobProps> = React.memo(
     const { position: translation, drag } = useDraggable({
       onDragEnd: imagePositionChanged,
     });
+    const [imageDimensions, setImageDimensions] = useState<{height: number; width: number}>({height: 100, width: 100});
+    const [scaleHeight, setScaleHeight] = useState<number>(imageScale);
+    const [scaleWidth, setScaleWidth] = useState<number>(imageScale);
 
     useEffect(
       function () {
@@ -44,6 +47,25 @@ const SvgBlob: React.FC<SvgBlobProps> = React.memo(
       },
       [image]
     );
+
+    useEffect( () => {
+      if (imageDimensions){
+        const [h, w] = [imageDimensions.height, imageDimensions.width];
+        setScaleHeight(h > w ? h/w*imageScale : imageScale);
+        setScaleWidth(w > h ? w/h*imageScale : imageScale);
+      }},
+      [imageScale, imageDimensions]
+    );
+
+    useEffect(() => {
+      if(imageString){
+        let img = new Image();
+        img.src = imageString;
+        img.onload = () => {
+          setImageDimensions({height: img.height, width: img.width})
+        }
+      }
+    }, [imageString])
 
     return (
       <svg
@@ -75,11 +97,11 @@ const SvgBlob: React.FC<SvgBlobProps> = React.memo(
             <image
               onMouseDown={drag}
               clipPath="url(#mask)"
-              height={`${imageScale}%`}
-              width={`${imageScale}%`}
+              height={`${scaleHeight}%`}
+              width={`${scaleWidth}%`}
               x={translation.x}
               y={translation.y}
-              preserveAspectRatio="xMinYMin slice"
+              preserveAspectRatio="xMidYMid"
               xlinkHref={imageString}
               style={{ cursor: "move" }}
             />

--- a/web/styleguide/components/svg-blob/index.tsx
+++ b/web/styleguide/components/svg-blob/index.tsx
@@ -63,6 +63,7 @@ const SvgBlob: React.FC<SvgBlobProps> = React.memo(
         img.src = imageString;
         img.onload = () => {
           setImageDimensions({height: img.height, width: img.width})
+          img.remove()
         }
       }
     }, [imageString])


### PR DESCRIPTION
Fixes #34 by making the dimensions of the image-element match the aspect ratio of the source image. Image scale is now used to set the size of the image's short edge, with the long edge being set to image scale multiplied by image aspect ratio.